### PR TITLE
Quick update to the deploy script since the upgrade to rsconnect 1.0

### DIFF
--- a/.github/workflows/deploy-shiny.yaml
+++ b/.github/workflows/deploy-shiny.yaml
@@ -76,5 +76,5 @@ jobs:
         run: >
           Rscript
           -e "rsconnect::setAccountInfo(name = 'department-for-education', token = '${{secrets.SHINYAPPS_TOKEN}}', secret = '${{secrets.SHINYAPPS_SECRET}}')"
-          -e "rsconnect::deployApp(appName=${{env.SHINYAPP_NAME}})"
+          -e "rsconnect::deployApp(appName=${{env.SHINYAPP_NAME}}, forceUpdate = TRUE)"
           


### PR DESCRIPTION
## Pull request overview

Since rsconnect 1.0 came in, we need the forceupdate=TRUE flag in the deploy script for the deploy to be successful